### PR TITLE
Restore default GNSS band and frequency mappings

### DIFF
--- a/src/LibGnut/gset/gsetgnss.cpp
+++ b/src/LibGnut/gset/gsetgnss.cpp
@@ -452,8 +452,6 @@ namespace gnut
 
         if (v_tmp.empty())
         {
-            throw logic_error("You need set your band for " + t_gsys::gsys2str(gsys) + " in xml file");
-
             switch (gsys)
             {
                 case GPS:
@@ -475,6 +473,7 @@ namespace gnut
                 case QZS:
                     v_tmp.push_back(BAND_1);
                     v_tmp.push_back(BAND_2);
+                    break;
                 default:
                     break;
             }
@@ -520,6 +519,7 @@ namespace gnut
                 case QZS:
                     v_tmp.push_back(FREQ_1);
                     v_tmp.push_back(FREQ_2);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
## Summary

- use the existing per-system default band mappings when `<band>` is omitted
- keep the corresponding default frequency mappings available
- terminate the QZSS band and frequency switch cases explicitly

## Problem

`t_gsetgnss::_band()` throws immediately when no band list is configured. This makes the default mappings directly below the exception unreachable, even though defaults are already defined for GPS, GLONASS, Galileo, BDS, and QZSS.

As a result, configurations that rely on the default behavior fail during initialization with:

```text
You need set your band for ... in xml file
```

## Fix

Remove the unconditional exception so the existing constellation-specific defaults are used, and add the missing `break` statements to the QZSS cases in both `_band()` and `_freq()`.

## Verification

Tested from commit `3b4f383a2724c1b0c4748cb0b0cb80e0bc430740` on Windows with MSVC Release:

- full Release build succeeds
- a one-epoch PPP run with all constellation `<band>`/`<freq>` settings omitted completes successfully (`exit 0`)
- the same run with explicit GPS band/frequency settings remains successful (`exit 0`)
- `git diff --check` passes

No observation data, generated products, binaries, or local paths are included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)