### PR TITLE
Handle missing satellite objects and extend BDS satellite identifiers

### DIFF
--- a/src/LibGREAT/gproc/gpvtflt.cpp
+++ b/src/LibGREAT/gproc/gpvtflt.cpp
@@ -974,6 +974,12 @@ int great::t_gpvtflt::_preprocess(const string& ssite, vector<t_gsatdata>& sdata
         if (!_isBase)
         {
             shared_ptr<t_gobj> sat_obj = this->_gallobj->obj(satname);
+            if (!sat_obj)
+            {
+                GREAT_WARN(ssite + _epoch.str_ymdhms(" epoch ") + " satellite object not found: " + satname);
+                iter = sdata.erase(iter);
+                continue;
+            }
             shared_ptr<t_gpcv> sat_pcv = sat_obj->pcv(_epoch);
             if (!sat_pcv)
             {

--- a/src/LibGnut/gutils/gnss.cpp
+++ b/src/LibGnut/gutils/gnss.cpp
@@ -47,7 +47,9 @@ namespace gnut
                   (string) "C22", (string) "C23", (string) "C24", (string) "C25", (string) "C26", (string) "C27", (string) "C28",
                   (string) "C29", (string) "C30", (string) "C31", (string) "C32", (string) "C33", (string) "C34", (string) "C35",
                   (string) "C36", (string) "C37", (string) "C38", (string) "C39", (string) "C40", (string) "C41", (string) "C42",
-                  (string) "C43", (string) "C44", (string) "C45", (string) "C46", (string) "C59", (string) "C60"};
+                  (string) "C43", (string) "C44", (string) "C45", (string) "C46", (string) "C47", (string) "C48", (string) "C49",
+                  (string) "C50", (string) "C51", (string) "C52", (string) "C53", (string) "C54", (string) "C55", (string) "C56",
+                  (string) "C57", (string) "C58", (string) "C59", (string) "C60", (string) "C61", (string) "C62", (string) "C63"};
 
         m[SBS] = {(string) "S20",
                   (string) "S24",


### PR DESCRIPTION
## Summary

- extend the static BDS satellite identifier list from C01-C46/C59-C60 through C01-C63
- guard against a missing satellite object before accessing its antenna calibration
- warn and skip an observation safely if an unknown satellite identifier is encountered

## Problem

The static BDS satellite list omits C47-C58 and C61-C63. When an observation contains one of these satellites, such as C56, `t_gallobj::obj()` returns an empty `shared_ptr` even when the ANTEX file contains a calibration record for that satellite.

`great::t_gpvtflt::_preprocess()` then dereferences it unconditionally:

```cpp
shared_ptr<t_gobj> sat_obj = this->_gallobj->obj(satname);
shared_ptr<t_gpcv> sat_pcv = sat_obj->pcv(_epoch);
```

This causes a segmentation fault/access violation at the first epoch containing C56.

## Fix

1. Add C47-C58 and C61-C63 to the BDS satellite identifier list, allowing valid current BDS satellites to be initialized normally.
2. Retain a null check in `_preprocess()` so a future unknown or unavailable satellite object produces a warning and is removed from that epoch instead of crashing the process.

## Verification

Tested from commit `3b4f383a2724c1b0c4748cb0b0cb80e0bc430740` using an ANTEX file containing a C56 record:

- before the fix, processing stops with a segmentation fault when C56 first appears
- after the fix, C56 is resolved as a normal satellite object rather than skipped
- all nine previously failing observation datasets pass their original trigger epochs and complete with `exit 0`
- two delayed failures were reproduced at the exact epochs where C56 first appeared and both complete after the fix
- a good-environment static observation regression also completes successfully
- MSVC Release build and `git diff --check` pass

No observation data, generated products, binaries, or local paths are included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)